### PR TITLE
feat : 로그인 API, 토큰, 로컬스토리지 구현

### DIFF
--- a/src/apis/base.ts
+++ b/src/apis/base.ts
@@ -1,0 +1,99 @@
+import axios from "axios";
+import renewTokens from "@/utils/token/renewTokens";
+import { getTokens } from "@/utils/token/token";
+import { useQueryClient } from "@tanstack/react-query";
+
+export const BASE_URL = process.env.NEXT_PUBLIC_API_KEY;
+
+const request = axios.create({
+  baseURL: BASE_URL,
+});
+
+request.interceptors.request.use(
+  async config => {
+    const { accessToken, refreshToken } = getTokens() || {}; // 기본값 추가
+    if (!refreshToken) {
+      window.location.href = '';
+      return config;
+    }
+
+    if (!accessToken) {
+      try {
+        const tokens = await renewTokens();
+        if (tokens && tokens.accessToken && tokens.refreshToken) {
+          // 로컬 스토리지에 토큰 저장
+          localStorage.setItem('accessToken', tokens.accessToken);
+          localStorage.setItem('refreshToken', tokens.refreshToken);
+          config.headers['Authorization'] = `Bearer ${tokens.accessToken}`;
+        } else {
+          throw new Error('토큰 갱신 실패');
+        }
+      } catch (error) {
+        console.error('토큰 갱신 중 오류 발생:', error);
+        window.location.href = ''; // 오류 발생 시 리다이렉트
+        return config;
+      }
+    } else {
+      config.headers['Authorization'] = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  error => {
+    console.log('에러발생');
+    console.error(error);
+    return Promise.reject(error);
+  },
+);
+
+// accessToken 만료시
+request.interceptors.response.use(
+  response => {
+    return response;
+  },
+  async error => {
+    const originalRequest = error.config;
+    const status = error.response?.status;
+    if (status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        const tokens = await renewTokens();
+        if (tokens && tokens.accessToken) {
+          // 로컬 스토리지에 새로운 엑세스 토큰 저장
+          localStorage.setItem('accessToken', tokens.accessToken);
+          originalRequest.headers.Authorization = `Bearer ${tokens.accessToken}`;
+          return request(originalRequest);
+        } else {
+          throw new Error('토큰 갱신 실패');
+        }
+      } catch (err) {
+        return Promise.reject(err);
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
+// refreshToken 만료시
+request.interceptors.response.use(
+  response => {
+    return response;
+  },
+  async error => {
+    console.log('api error', error);
+    const status = error.response?.status;
+    const message = error.response?.data.message;
+
+    if (status === 500 && message === '회원이 존재하지 않습니다.') {
+      // 로컬 스토리지에서 리프레시 토큰 삭제
+      localStorage.removeItem('refreshToken');
+      localStorage.removeItem('accessToken'); // 엑세스 토큰도 삭제할 수 있습니다.
+      window.location.href = '';
+
+      const queryClient = useQueryClient();
+      queryClient.clear();
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default request;

--- a/src/apis/login/login.ts
+++ b/src/apis/login/login.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 import { LoginUserProps } from "@/types/login/types";
-
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+import { BASE_URL } from "../base";
 
 export const postLogin = async ({ email, password }: LoginUserProps) => {
     const formData = new FormData();

--- a/src/utils/localStorage/localStorage.ts
+++ b/src/utils/localStorage/localStorage.ts
@@ -1,0 +1,11 @@
+export const setItem = (key: string, value: string) => {
+    localStorage.setItem(key, value);
+  };
+  
+  export const getItem = (key: string) => {
+    return localStorage.getItem(key);
+  };
+  
+  export const removeItem = (key: string) => {
+    localStorage.removeItem(key);
+  };

--- a/src/utils/token/renewTokens.ts
+++ b/src/utils/token/renewTokens.ts
@@ -1,0 +1,22 @@
+import { setToken } from "./token";
+import { postMemberRefresh } from "@/apis/login/login";
+import { getItem, setItem } from "../localStorage/localStorage";
+
+
+const renewTokens = async () => {
+    const refreshToken = getItem('refreshToken');
+    if(refreshToken) {
+        const response = await postMemberRefresh(refreshToken);
+
+        const newAccessToken = response.accessToken;
+        const newRefreshToken = response.refreshToken;
+
+        setToken(newAccessToken);
+        setItem('refreshToken', newRefreshToken);
+        return { accessToken: newAccessToken, refreshToken: newRefreshToken };
+    } else {
+        console.error("refreshToken이 없습니다.");
+    }
+};
+
+export default renewTokens;

--- a/src/utils/token/token.ts
+++ b/src/utils/token/token.ts
@@ -1,0 +1,11 @@
+let accessToken = '';
+
+export const setToken = (token: string) => {
+  accessToken = token;
+  localStorage.setItem('accessToken', token); // 로컬 스토리지에 accessToken 저장
+};
+
+export const getTokens = () => {
+  const refreshToken = localStorage.getItem('refreshToken'); // 로컬 스토리지에서 refreshToken 가져오기
+  return { accessToken, refreshToken };
+};


### PR DESCRIPTION
# 작업분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
utils 폴더안에 token 구현
apis/base.ts 구현

# 작업 상세 내용
base.ts -> token 저장 및 만료 되었을 때 재발급 api 호출
로컬스토리지로 토큰 저장 및 삭제하는 함수 작성
토큰 재발급 및 토큰 생성, 가져오는 함수 작성

# 리뷰 요구사항
일단 컴포넌트는 구현하지 않고, 생각나는만큼 토큰 생성 및 api 호출을 작성했습니다.
이후 로그인 컴포넌트 구현하고나서 연동했을 때 테스트 할 예정입니다.

# 기타

