### PR TITLE
feat: 목록페이지와 상세페이지 연동

### DIFF
--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -293,7 +293,7 @@ const Home: React.FC = () => {
             <div
               key={article.id}
               className="bg-white shadow-md rounded-md overflow-hidden cursor-pointer"
-              onClick={() => router.push(`/articles/${article.id}`)}
+              onClick={() => router.push(`/board/${article.id}`)}
             >
               <img
                 src={article.image}
@@ -347,7 +347,7 @@ const Home: React.FC = () => {
               <tr
                 key={article.id}
                 className="hover:bg-gray-50 cursor-pointer h-[49px] text-gray-700"
-                onClick={() => router.push(`/articles/${article.id}`)}
+                onClick={() => router.push(`/board/${article.id}`)}
               >
                 <td className="border-b border-gray-200 px-4 py-2 text-center">
                   {article.id}


### PR DESCRIPTION
# 작업분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 리팩토링
- [ ] 기타

# 작업개요
- 게시글 목록페이지와 상세페이지 연동
- 
![localhost_3001_board-Chrome-2024-09-11-21-06-46](https://github.com/user-attachments/assets/e25c8cff-2031-4890-9bd1-2aad09e1daa7)


# 작업 상세 내용
- 목록페이지에서 게시글 누를 시 상세페이지로 이동

# 리뷰 요구사항
- 피드백할 점 리뷰해주시면 감사하겠습니다

# 기타
- 데이터 문제가 아니라 제가 경로를 잘못설정해서 안나오는거였네요ㅎㅎ;